### PR TITLE
style glossary links decently

### DIFF
--- a/src/less/website/markup.less
+++ b/src/less/website/markup.less
@@ -1,8 +1,10 @@
 .markdown-section {
     .gitbook-markdown(@md-color: @content-color, @md-line-height: @content-line-height);
 
-    .glossary-term {
+    .glossary-term, .glossary-term:hover {
+        color: desaturate(@content-color, 50%);
         cursor: help;
         text-decoration: underline;
+        text-decoration-style: dashed;
     }
 }


### PR DESCRIPTION
default link styling was way to distracting for the reader when there are many glossary terms.

now using desaturated text-color & dashed underline, as it's common on other sites.
