### PR TITLE
Fix ie scroll in protocal file:// hash change

### DIFF
--- a/src/js/theme/navigation.js
+++ b/src/js/theme/navigation.js
@@ -130,6 +130,7 @@ function setChapterActive($chapter, hash) {
         uri = window.location.pathname + hash;
 
     if (uri != oldUri) {
+        uri = uri.replace(/(\/[A-Z]:)+/, '');
         history.replaceState({ path: uri }, null, uri);
     }
 }


### PR DESCRIPTION
[IE scroll change hash make wrong url](https://github.com/GitbookIO/theme-default/issues/38)
My env is win7, ie11.
It should be an ie bug, other browsers work good.
I just remove the disk part of uri before history.replaceState use it.