### PR TITLE
Fix a bug.

### DIFF
--- a/src/js/theme/navigation.js
+++ b/src/js/theme/navigation.js
@@ -354,7 +354,8 @@ function preparePage(resetScroll) {
         }
 
         var resolvedRef = url.resolve(window.location.pathname, href);
-        return window.location.pathname == resolvedRef;
+        return decodeURI(window.location.pathname) == decodeURI(resolvedRef);
+        /* See https://github.com/GitbookIO/gitbook/issues/1525 */
     });
 
     // Bind scrolling if summary contains more than one link to this page


### PR DESCRIPTION
See https://github.com/GitbookIO/gitbook/issues/1525

window.location.pathname is encoded, but resolvedRef is not.
For example,
* window.location.pathname=http://example.com/%E4%B8%AD%E6%96%87
* resolved=http://example.com/中文
They're the same, but window.location.pathname!=resolved.

So It will throw a error.
>Uncaught TypeError: Cannot read property 'split' of undefined
    at u (theme.js:4)
    at s (theme.js:4)
    at HTMLDivElement.l (theme.js:4)
    at HTMLDivElement.dispatch (theme.js:2)
    at HTMLDivElement.m.handle (theme.js:2)