### PR TITLE
AJAX: prevent header elements from being replaced

### DIFF
--- a/src/js/theme/navigation.js
+++ b/src/js/theme/navigation.js
@@ -229,7 +229,7 @@ function handleNavigation(relativeUrl, push) {
                 var responseURL = xhr.getResponseHeader('X-Current-Location') || uri;
 
                 // Replace html content
-                html = html.replace( /<(\/?)(html|head|body)([^>]*)>/ig, function(a,b,c,d){
+                html = html.replace( /<(\/?)(html|head|body)[>\s]([^>]*)>?/ig, function(a,b,c,d){
                     return '<' + b + 'div' + ( b ? '' : ' data-element="' + c + '"' ) + d + '>';
                 });
 


### PR DESCRIPTION
stumbled on this bug, while using a <header> element which got replaced, when handling a change of url without refresh of the whole page.

fixes GitbookIO/theme-default#46

https://regex101.com/r/65iazM/1