### PR TITLE
Added null/empty jQuery check & default top val

### DIFF
--- a/src/js/theme/navigation.js
+++ b/src/js/theme/navigation.js
@@ -71,9 +71,9 @@ function getElementTopPosition(id) {
 
     dest = $el.position().top;
 
-    while (!$parent.is($container)) {
+    while ($parent && $parent.length && !$parent.is($container)) {
         $el = $parent;
-        dest += $el.position().top;
+        dest += ($el.position() || {}).top || 0;
         $parent = $el.offsetParent();
     }
 


### PR DESCRIPTION
Based on this error I get when running GitBook 3.2.2:

```
Uncaught TypeError: Cannot read property 'top' of undefined
    at a (theme.js:formatted:5276)
    at HTMLLIElement.<anonymous> (theme.js:formatted:5315)
    at Function.each (theme.js:formatted:784)
    at de.fn.init.each (theme.js:formatted:694)
    at HTMLDivElement.l (theme.js:formatted:5313)
    at HTMLDivElement.dispatch (theme.js:formatted:2468)
    at HTMLDivElement.m.handle (theme.js:formatted:2400)
```

Accordingly, I've added

# A null check to the `while` loop of `getElementTopPosition`
# An empty jQuery element check to the `while` loop of `getElementTopPosition`
# Sensible defaults should the call to `$el.position().top` in `getElementTopPosition` fail