### PR TITLE
Fix the translated sentence in ja.json

### DIFF
--- a/_i18n/ja.json
+++ b/_i18n/ja.json
@@ -8,7 +8,7 @@
     "SUMMARY_INTRODUCTION": "はじめに",
     "SUMMARY_TOGGLE": "目次",
     "SEARCH_TOGGLE": "検索",
-    "SEARCH_PLACEHOLDER": "検索すると入力",
+    "SEARCH_PLACEHOLDER": "入力して検索",
     "FONTSETTINGS_TOGGLE": "フォント設定",
     "SHARE_TOGGLE": "シェア",
     "SHARE_ON": "{{platform}}でシェア",


### PR DESCRIPTION
I'm Japanese.
Not ``"検索すると入力"`` but ``"入力して検索"`` seems more natural.