### PR TITLE
Reenable local file navigation

### DIFF
--- a/src/js/theme/navigation.js
+++ b/src/js/theme/navigation.js
@@ -323,6 +323,9 @@ function handleNavigation(relativeUrl, push) {
                 }
 
                 deferred.resolve();
+            },
+            error: function(html, status, error) {
+                deferred.reject();
             }
         });
     }).promise();
@@ -331,7 +334,7 @@ function handleNavigation(relativeUrl, push) {
         promise
         .fail(function (e) {
             console.log(e); // eslint-disable-line no-console
-            // location.href = relativeUrl;
+            location.href = relativeUrl;
         })
     );
 }


### PR DESCRIPTION
Loads navigation through redirect if ajax fails

When $.get call was replaced with $.ajax it broke the local file navigation, as CORD will prevent to succeed any call to $.ajax and the error was never handled. This change will propagate to the deferred the error so the promise fail will be called if the $.ajax call fails.
https://github.com/GitbookIO/theme-default/commit/d94ae0f808adf170e1bda3341a75d1e462e0e8f5

This pr should fix this issue: https://github.com/GitbookIO/theme-default/issues/28
