### PR TITLE
Link to asset files navigated directly

### DIFF
--- a/src/js/theme/navigation.js
+++ b/src/js/theme/navigation.js
@@ -232,7 +232,10 @@ function handleNavigation(relativeUrl, push) {
     // Is it an absolute url
     var isAbsolute = Boolean(uriParsed.hostname);
 
-    if (!usePushState || isAbsolute) {
+    // Is it a HTML file rather than an asset file (image, etc.)
+    var isHtml = /\.html$/.test(uriParsed.pathname);
+
+    if (!usePushState || isAbsolute || !isHtml) {
         // Refresh the page to the new URL if pushState not supported
         location.href = relativeUrl;
         return;


### PR DESCRIPTION
The existing implementation treats all relative links as HTMLs and attempt to render them.

However, for links directly pointing to asset files (images, archive files, etc.), the files themselves should be directly opened instead.

This PR fixes the issue https://github.com/GitbookIO/gitbook/issues/1923 (where the issue creator is linking to CSV files).