### PR TITLE
i18n for zh-cn and zh-hant

### DIFF
--- a/_i18n/zh-cn.json
+++ b/_i18n/zh-cn.json
@@ -1,0 +1,20 @@
+{
+    "LANGS_CHOOSE": "选择一种语言",
+    "GLOSSARY": "术语表",
+    "GLOSSARY_INDEX": "索引",
+    "GLOSSARY_OPEN": "术语表",
+    "GITBOOK_LINK": "本书使用 GitBook 发布",
+    "SUMMARY": "目录",
+    "SUMMARY_INTRODUCTION": "介绍",
+    "SUMMARY_TOGGLE": "目录",
+    "SEARCH_TOGGLE": "搜索",
+    "SEARCH_PLACEHOLDER": "输入并搜索",
+    "FONTSETTINGS_TOGGLE": "字体设置",
+    "SHARE_TOGGLE": "分享",
+    "SHARE_ON": "分享到 {{platform}}",
+    "FONTSETTINGS_WHITE": "白色",
+    "FONTSETTINGS_SEPIA": "棕褐色",
+    "FONTSETTINGS_NIGHT": "夜间",
+    "FONTSETTINGS_SANS": "无衬线体",
+    "FONTSETTINGS_SERIF": "衬线体"
+}

--- a/_i18n/zh-hant.json
+++ b/_i18n/zh-hant.json
@@ -1,0 +1,20 @@
+{
+    "LANGS_CHOOSE": "選擇一種語言",
+    "GLOSSARY": "術語表",
+    "GLOSSARY_INDEX": "索引",
+    "GLOSSARY_OPEN": "術語表",
+    "GITBOOK_LINK": "本書使用 GitBook 釋出",
+    "SUMMARY": "目錄",
+    "SUMMARY_INTRODUCTION": "介紹",
+    "SUMMARY_TOGGLE": "目錄",
+    "SEARCH_TOGGLE": "搜尋",
+    "SEARCH_PLACEHOLDER": "輸入並搜尋",
+    "FONTSETTINGS_TOGGLE": "字型設定",
+    "SHARE_TOGGLE": "分享",
+    "SHARE_ON": "分享到 {{platform}}",
+    "FONTSETTINGS_WHITE": "白色",
+    "FONTSETTINGS_SEPIA": "棕褐色",
+    "FONTSETTINGS_NIGHT": "夜間",
+    "FONTSETTINGS_SANS": "無襯線體",
+    "FONTSETTINGS_SERIF": "襯線體"
+}


### PR DESCRIPTION
According to [BCP47](https://tools.ietf.org/html/bcp47), comparing to simplified chinese(zh-hans), traditional chinese should be "zh-hant", so I added the file zh-hant.json .
And for historical reason, zh-cn is wrongly used widely to indicate simplified chinese, it should be regarded as zh-hans for compatibility.
But it seems the i18n-t library treat "zh-cn" as "zh-tw" for its simple comparison function.
And thus there are some traditional chinese information in many simplified chinese books who are using zh-cn.
So the zh-cn.json is added.