### PR TITLE
Fix PDF table of content bookmarks

### DIFF
--- a/src/less/ebook/base.less
+++ b/src/less/ebook/base.less
@@ -17,7 +17,10 @@ body {
 
     // Hide the title (only used to build PDF table of content)
     .book-chapter {
-        display: none;
+        visibility:hidden;
+        overflow:hidden;
+        height:0;
+        width:0;
     }
 }
 


### PR DESCRIPTION
Set the book-chapter visibility to hidden because the elements with none display
are not included in the PDF docs breaking the table of content bookmarks.